### PR TITLE
Show more information about reasons for app incompatiblity.

### DIFF
--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -64,7 +64,7 @@ class AppManagerWidget(ipw.VBox):
     versions if possible.
     """
 
-    COMPATIBILTIY_WARNING = Template("""<div class="alert alert-warning">
+    COMPATIBILTIY_WARNING = Template("""<div class="alert alert-danger">
     The installed version of this app is not compatible with this AiiDAlab environment.
     </div>""")
 

--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -64,11 +64,25 @@ class AppManagerWidget(ipw.VBox):
     versions if possible.
     """
 
-    COMPATIBILTIY_WARNING = Template("""<p style="background-color:#FFCC00; text-align:center;">
-    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    COMPATIBILTIY_WARNING = Template("""<div class="alert alert-warning">
     The installed version of this app is not compatible with this AiiDAlab environment.
-    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-    </p>""")
+    </div>""")
+
+    COMPATIBILITY_INFO = Template("""<div class="alert alert-warning alert-dismissible">
+        <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
+            Reasons for incompatibility:
+            <ul>
+            {% for spec in app.compatibility_info %}
+                <li>{{ spec }}:
+                    <ul>
+                        {% for missing_req in app.compatibility_info[spec] %}
+                        <li>missing: {{ missing_req }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endfor %}
+            </ul>
+        </div>""")
 
     TEMPLATE = Template("""<b> <div style="font-size: 30px; text-align:center;">{{ app.title }}</div></b>
     <br>
@@ -107,6 +121,8 @@ class AppManagerWidget(ipw.VBox):
         self.blocked_ignore = ipw.Checkbox(description="Ignore")
         self.blocked_ignore.observe(self._refresh_widget_state)
 
+        self.compatibility_info = ipw.HTML()
+
         self.spinner = Spinner("color:#337ab7;font-size:1em;")
         ipw.dlink((self.app, 'busy'), (self.spinner, 'enabled'))
 
@@ -116,6 +132,7 @@ class AppManagerWidget(ipw.VBox):
             ipw.HBox([self.uninstall_button, self.install_button, self.update_button, self.spinner]),
             ipw.HBox([self.install_info]),
             ipw.HBox([self.issue_indicator, self.blocked_ignore]),
+            ipw.HBox([self.compatibility_info]),
         ]
 
         self.version_selector = VersionSelectorWidget()
@@ -242,6 +259,11 @@ class AppManagerWidget(ipw.VBox):
             else:
                 self.issue_indicator.value = ''
             self.blocked_ignore.layout.visibility = 'visible' if (detached or not compatible) else 'hidden'
+
+            if any(self.app.compatibility_info.values()) and self.app.compatible is False:
+                self.compatibility_info.value = self.COMPATIBILITY_INFO.render(app=self.app)
+            else:
+                self.compatibility_info.value = ""
 
     def _show_msg_success(self, msg):
         """Show a message indicating successful execution of a requested operation."""


### PR DESCRIPTION
This change set updates the presentation of incompatibility warnings within the app manager interface by

1. Switching to a standard alert box style for the app incompatibility message and
2. Adding an additional alert warning message below version selector with more information about why a particular app is considered incompatible (requires https://github.com/aiidalab/aiidalab/pull/147 ).

Resolves #52 .

![Screen Shot 2021-02-04 at 17 22 37](https://user-images.githubusercontent.com/1441208/106923131-0d94f100-670e-11eb-975a-b3635e40c8f8.png)
