### PR TITLE
Import start.py using absolute path.

### DIFF
--- a/home/utils.py
+++ b/home/utils.py
@@ -1,7 +1,7 @@
 """Helpful utilities for the AiiDAlab tools."""
 
 import sys
-from importlib import util
+from importlib.machinery import SourceFileLoader
 from os import path
 
 import ipywidgets as ipw
@@ -19,11 +19,9 @@ def load_start_py(name):
     """Load app appearance from a Python file."""
     try:
         # Loading start.py from the app's folder
-        spec = util.spec_from_file_location(
+        mod = SourceFileLoader(
             "start", path.join(AIIDALAB_APPS, name, "start.py")
-        )
-        mod = util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        ).load_module()
 
         appbase = "../" + name
         jupbase = "../../.."

--- a/home/utils.py
+++ b/home/utils.py
@@ -1,7 +1,7 @@
 """Helpful utilities for the AiiDAlab tools."""
 
 import sys
-from importlib import import_module
+from importlib import util
 from os import path
 
 import ipywidgets as ipw
@@ -18,7 +18,11 @@ def load_widget(name):
 def load_start_py(name):
     """Load app appearance from a Python file."""
     try:
-        mod = import_module("apps.%s.start" % name)
+        # Loading start.py from the app's folder
+        spec = util.spec_from_file_location("start", path.join(AIIDALAB_APPS, name, "start.py"))
+        mod = util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
         appbase = "../" + name
         jupbase = "../../.."
         notebase = jupbase + "/notebooks/apps/" + name

--- a/home/utils.py
+++ b/home/utils.py
@@ -19,7 +19,9 @@ def load_start_py(name):
     """Load app appearance from a Python file."""
     try:
         # Loading start.py from the app's folder
-        spec = util.spec_from_file_location("start", path.join(AIIDALAB_APPS, name, "start.py"))
+        spec = util.spec_from_file_location(
+            "start", path.join(AIIDALAB_APPS, name, "start.py")
+        )
         mod = util.module_from_spec(spec)
         spec.loader.exec_module(mod)
 


### PR DESCRIPTION
Previously, the apps folder was considered a python module. Since
this is not true anymore [1,2], the loading of the apps' start.py
needs to be adapted.

[1] https://github.com/aiidateam/aiida-prerequisites/pull/37
[2] https://github.com/aiidalab/aiidalab-docker-stack/pull/213