### PR TITLE
Update min version of aiidalab dependency.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     ipywidgets~=7.6
     jinja2~=2.11
     traitlets~=5.0
+python_requires = >=3.7
 
 [options.extras_require]
 pre_commit =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,12 +25,11 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    aiidalab>=v21.06.0
+    aiidalab>=v21.10.2
     ipython~=7.25
     ipywidgets~=7.6
     jinja2~=2.11
-    traitlets~=4.3
-python_requires = >=3.7
+    traitlets~=5.0
 
 [options.extras_require]
 pre_commit =


### PR DESCRIPTION
fixes #76 

The min version of aiidalab is set to be >= 21.10.2.
Previously, `logo` was an attribute of the `_AiidaLabApp` class.
Now it is a part of its metadata.