### PR TITLE
The compatible info only show for installed app

### DIFF
--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -397,6 +397,7 @@ class AppManagerWidget(ipw.VBox):
                 not busy
                 and any(self.app.compatibility_info.values())
                 and self.app.compatible is False
+                and self.app.is_installed()
             ):
                 self.compatibility_info.value = self.COMPATIBILITY_INFO.render(
                     app=self.app

--- a/single_app.ipynb
+++ b/single_app.ipynb
@@ -73,7 +73,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -87,7 +87,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #100 

The compatible info will be shown during the installation, which is not the expected behavior. The compatible info is only shown for the app installed.