### PR TITLE
Simple URL sanitization

### DIFF
--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -96,7 +96,7 @@ class AppManagerWidget(ipw.VBox):
     <b>Authors:</b> {{ app.authors }}
     <br>
     <b>Description:</b> {{ app.description }}
-    {% if app.url %}
+    {% if app.url and app.url.startswith("http") %}
     <br>
     <b>URL:</b> <a href="{{ app.url }}">{{ app.url }}</a>
     {% endif %}"""


### PR DESCRIPTION
Currently, if the app URL is not found in app metadata, the `app.url` variable (that we render on the single app page) is not None, but instead it is a string

>  "Field 'external_url' not present in app metadata". 

When this string is rendered as a href target, it results in an invalid link leading to a 404 page.

Here's we just add a simple validation to check that the URL starts with http.

This is a hotfix solution to https://github.com/aiidalab/aiidalab/issues/329 until the root cause is fixed. Note that this bug affects AWB and a bunch of other apps. I still did not find out why it affects some apps and not the others.