### PR TITLE
Enlarge output from a running installation

### DIFF
--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -5,11 +5,11 @@ from subprocess import CalledProcessError
 
 import ipywidgets as ipw
 import traitlets
+from aiidalab.app import AppRemoteUpdateStatus as AppStatus
+from aiidalab.app import AppVersion
 from jinja2 import Template
 from packaging.version import parse
 
-from aiidalab.app import AppRemoteUpdateStatus as AppStatus
-from aiidalab.app import AppVersion
 from home.utils import load_logo
 from home.widgets import LogOutputWidget, Spinner, StatusHTML
 

--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -5,11 +5,11 @@ from subprocess import CalledProcessError
 
 import ipywidgets as ipw
 import traitlets
-from aiidalab.app import AppRemoteUpdateStatus as AppStatus
-from aiidalab.app import AppVersion
 from jinja2 import Template
 from packaging.version import parse
 
+from aiidalab.app import AppRemoteUpdateStatus as AppStatus
+from aiidalab.app import AppVersion
 from home.utils import load_logo
 from home.widgets import LogOutputWidget, Spinner, StatusHTML
 
@@ -410,9 +410,7 @@ class AppManagerWidget(ipw.VBox):
 
     def _show_msg_failure(self, msg):
         """Show a message indicating failure to execute a requested operation."""
-        # DH: Setting the value directly so that the error message
-        # does not disappear
-        self.install_info.value = HTML_MSG_FAILURE.format(msg)
+        self.install_info.show_temporary_message(HTML_MSG_FAILURE.format(msg))
 
     def _check_detached_state(self):
         """Check whether the app is in a detached state which would prevent any install or other operations."""

--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -118,7 +118,7 @@ class AppManagerWidget(ipw.VBox):
         )  # show empty line by default
 
         self.dependencies_log = LogOutputWidget(
-            layout=ipw.Layout(min_height="0px", max_height="100px")
+            layout=ipw.Layout(min_height="0px", max_height="400px")
         )  # max_height controls the maximum height of the log field.
         self.dependencies_log.template = (
             "Installing dependencies..." + self.dependencies_log.template
@@ -410,7 +410,9 @@ class AppManagerWidget(ipw.VBox):
 
     def _show_msg_failure(self, msg):
         """Show a message indicating failure to execute a requested operation."""
-        self.install_info.show_temporary_message(HTML_MSG_FAILURE.format(msg))
+        # DH: Setting the value directly so that the error message
+        # does not disappear
+        self.install_info.value = HTML_MSG_FAILURE.format(msg)
 
     def _check_detached_state(self):
         """Check whether the app is in a detached state which would prevent any install or other operations."""


### PR DESCRIPTION
Enlarging the console output from a running installation to make it easier to see what is happening. Closes #139

OLD:

![image](https://user-images.githubusercontent.com/9539441/220647105-e20133bf-249b-4c11-9dc7-4811d6e148f3.png)


NEW:
![image](https://user-images.githubusercontent.com/9539441/220647024-014abc8f-9d3a-4146-b735-55445db815ef.png)
