### PR TITLE
Add detached check before raise imcompatible warning.

### DIFF
--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -303,7 +303,12 @@ class AppManagerWidget(ipw.VBox):
             ) and not self.blocked_ignore.value
 
             # Check the compatibility of current installed version and show banner if not compatible.
-            if not busy and installed and not self.app.compatible:
+            if (
+                not busy
+                and installed
+                and not self.app.compatible
+                and not self.app.detached
+            ):
                 self.header_warning.show(
                     "The installed version of this app is not compatible with this AiiDAlab environment."
                 )


### PR DESCRIPTION
fixes #https://github.com/aiidalab/aiidalab/issues/373

The detached check works fine but since it is detached the version will be `UNKNOWN` and in the compatible check it is regarded as incompatible. I also add a docstring in https://github.com/aiidalab/aiidalab/pull/374