### PR TITLE
Disable prompt for appstore and single app page

### DIFF
--- a/appstore.ipynb
+++ b/appstore.ipynb
@@ -19,6 +19,9 @@
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
     "    return false;\n",
+    "}\n",
+    "if (document.getElementById('appmode-busy')) {\n",
+    "    window.onbeforeunload = function() {return}\n",
     "}"
    ]
   },

--- a/single_app.ipynb
+++ b/single_app.ipynb
@@ -9,6 +9,9 @@
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
     "    return false;\n",
+    "}\n",
+    "if (document.getElementById('appmode-busy')) {\n",
+    "    window.onbeforeunload = function() {return}\n",
     "}"
    ]
   },


### PR DESCRIPTION
This is a follow up on #141 where we disabled the alert prompt when leaving the home page. We've been using it for quite a while since and haven't noticed any issues so it's time to apply to other apps / pages.

In the future, we should ideally apply this fix directly in Appmode, but that will require more work so for now here's just a simple hotfix.