### PR TITLE
Pin notebook version to v6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     ipywidgets~=7.6
     traitlets~=5.0
     widgetsnbextension<3.6.3
+    notebook~=6.0
 python_requires = >=3.9
 
 [options.extras_require]


### PR DESCRIPTION
We currently don't support Notebook v7 (tracked in #177). Until we do, let's pin the notebook version. (currently, running `pip install .` in empty environment installs notebook v7)