### PR TITLE
Fix crash in single_app.ipynb from invalid version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: continuous-integration
 on:
     push:
         branches:
-            - master
+            - main
     pull_request:
 
 env:

--- a/home/app_manager.py
+++ b/home/app_manager.py
@@ -7,7 +7,7 @@ import traitlets
 from aiidalab.app import AppRemoteUpdateStatus as AppStatus
 from aiidalab.app import AppVersion
 from jinja2 import Template
-from packaging.version import parse
+from packaging.version import InvalidVersion, parse
 
 from home.utils import load_logo
 from home.widgets import LogOutputWidget, Spinner, StatusHTML
@@ -258,11 +258,14 @@ class AppManagerWidget(ipw.VBox):
         installed_version = app.installed_version
 
         has_prereleases = app.has_prereleases
-        prerelease_installed = (
-            parse(installed_version).is_prerelease
-            if isinstance(installed_version, str)
-            else False
-        )
+        prerelease_installed = False
+        if isinstance(installed_version, str):
+            try:
+                parsed_version = parse(installed_version)
+            except InvalidVersion:
+                pass
+            else:
+                prerelease_installed = parsed_version.is_prerelease
 
         with self.hold_trait_notifications():
             # The checkbox can only be enabled when the app has prereleases,

--- a/single_app.ipynb
+++ b/single_app.ipynb
@@ -78,17 +78,7 @@
    "source": [
     "app_base = AiidaLabApp(name, app_data, AIIDALAB_APPS)\n",
     "\n",
-    "try:\n",
-    "    display(AppManagerWidget(app_base, minimalistic=False))\n",
-    "except Exception as error:\n",
-    "    display(\n",
-    "        ipw.HTML(\n",
-    "            '<div style=\"font-size: 30px; text-align:center;\">'\n",
-    "            f\"Unable to show app widget due to error: {error}\"\n",
-    "            \"</div>\",\n",
-    "            layout={\"width\": \"600px\"},\n",
-    "        )\n",
-    "    )"
+    "display(AppManagerWidget(app_base, minimalistic=False))"
    ]
   }
  ],


### PR DESCRIPTION
This is the same issue that I recently solved in the aiidalab and aiidalab-registry packages,
see aiidalab/aiidaslab#339 and aiidalab/aiidalab-registry#103 for details.

It did not occur to me that the same issue occurs here right in our AiiDAlab home!

Fixes #180

I'll trigger a rebuild of the Python 3.11 docker image with this branch to test this.