### PR TITLE
Make home notebook full width

### DIFF
--- a/start.ipynb
+++ b/start.ipynb
@@ -18,6 +18,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "html"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "\n",
+    "<style>\n",
+    "  .output_subarea {\n",
+    "    max-width: none !important;\n",
+    "  }\n",
+    "</style>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +100,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Jupyter adds a `max-width: calc(100% - 14ex)` property settings to the `output_subarea` class, which is everywhere. This PR overwrites it with `max-width: none` to allow container widgets to take up the full width of the notebook.