### PR TITLE
Replace `jinja2` with `markdown` for loading the warning message document

### DIFF
--- a/home/start_page.py
+++ b/home/start_page.py
@@ -125,16 +125,12 @@ class AiidaLabHome:
         self.write_config(config)
 
     def _create_notification(self, content):
-        from IPython.display import Markdown, display
-        from jinja2 import Environment
+        from markdown import Markdown
 
-        env = Environment()
-        notification = env.from_string(content).render()
-        output = ipw.Output()
-        notification_widget = ipw.VBox(children=[output])
+        md = Markdown()
+        html = md.convert(content)
+        notification_widget = ipw.HTML(html)
         notification_widget.add_class("home-notification")
-        with output:
-            display(Markdown(notification))
         return notification_widget
 
 


### PR DESCRIPTION
This PR fixes an instability with using `jinja2` and `IPython.display.Markdown` to load the warning message document. Here we instead use `markdown.Markdown` to convert the markdown document to HTML and render it using an `ipywidget.HTML` widget, which is simpler to work with (no `ipywidgets.Output` widgets required!).

When I add the `.aiidalab/home_app_warning.md` file, instead of adding the message after the home's control panel, it replaces the panel.

Before adding file
![image](https://github.com/user-attachments/assets/684a87d9-d89c-4088-bf9b-a847e0c3f582)

After adding file
![image](https://github.com/user-attachments/assets/caed3bf3-a313-4d4d-9a34-2cc62321d7db)

In this PR:

![image](https://github.com/user-attachments/assets/e5e1f993-97a5-4e9c-8566-0720eb403efc)
