### PR TITLE
Implement and utilize countdown widget (for temporary deployments)

### DIFF
--- a/home/widgets.py
+++ b/home/widgets.py
@@ -197,8 +197,8 @@ class CountDownWidget(ipw.VBox):
     TEMPLATE = "<h1 style='color: {color}'>Time remaining: <b>{countdown}</b></h1>"
     FINAL_WARNING = "<h1 style='color: red'>AiiDAlab container shutdown imminent - please save your work!</h1>"
 
-    def __init__(self, duration: str, **kwargs):
-        self.reference_time = datetime.strptime(duration, "%H:%M:%S")
+    def __init__(self, lifetime: str, **kwargs):
+        self.reference_time = datetime.strptime(lifetime, "%H:%M:%S")
 
         self.countdown = ipw.HTML()
 

--- a/home/widgets.py
+++ b/home/widgets.py
@@ -1,7 +1,7 @@
 """AiiDAlab basic widgets."""
 
-from datetime import datetime
 import subprocess
+from datetime import datetime
 from threading import Timer
 
 import ipywidgets as ipw

--- a/start.ipynb
+++ b/start.ipynb
@@ -52,6 +52,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from yaml import safe_load\n",
+    "\n",
+    "from home.widgets import CountDownWidget\n",
+    "\n",
+    "# For temporary deployments (e.g. demo server), duration is read from a local\n",
+    "# config file. This will initiate the countdown widget.\n",
+    "demo_server_config_file = Path.home() / \".aiidalab\" / \"demo-server-config.yml\"\n",
+    "if demo_server_config_file.exists():\n",
+    "    demo_server_config = safe_load(demo_server_config_file.read_text())\n",
+    "    countdown = CountDownWidget(duration=demo_server_config.get(\"duration\", \"12:00:00\"))\n",
+    "    countdown.start()\n",
+    "    display(countdown)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from home.start_page import AiidaLabHome\n",
     "\n",
     "home = AiidaLabHome()\n",

--- a/start.ipynb
+++ b/start.ipynb
@@ -60,10 +60,11 @@
     "# config file. This will initiate the countdown widget.\n",
     "demo_server_config_file = Path.home() / \".aiidalab\" / \"demo-server-config.yml\"\n",
     "if demo_server_config_file.exists():\n",
-    "    demo_server_config = safe_load(demo_server_config_file.read_text())\n",
-    "    countdown = CountDownWidget(duration=demo_server_config.get(\"duration\", \"12:00:00\"))\n",
-    "    countdown.start()\n",
-    "    display(countdown)"
+    "    demo_server_config: dict = safe_load(demo_server_config_file.read_text())  # type: ignore\n",
+    "    if \"lifetime\" in demo_server_config:\n",
+    "        countdown = CountDownWidget(lifetime=demo_server_config[\"lifetime\"])\n",
+    "        countdown.start()\n",
+    "        display(countdown)"
    ]
   },
   {


### PR DESCRIPTION
This PR implement a count down widget for use in temporary deployments. The widget is added to the main notebook within a check for a demo-server-config.yml file.

To test, add `~/.aiidalab/demo-server-config.yml` with `duration: "##:##:##"` in it. Try different times. In particular, try near 5 minutes to check the color change, and near 0 to see the final message.

Checking elapsed time is done via `ps -o etime= -p 1`, as suggested by @yakutovicha 

---

![image](https://github.com/user-attachments/assets/ca81a2b6-25cb-4a76-9e93-42bd6556908f)

![image](https://github.com/user-attachments/assets/2486d858-23d2-4d0d-9cd8-b9c2dbc18ac4)

![image](https://github.com/user-attachments/assets/b47a2d32-de8d-4bda-be92-ad223af61b9f)
