### PR TITLE
Consolidate AWB preview handling

### DIFF
--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -1,0 +1,31 @@
+"""Helpers for optional node previews."""
+
+from __future__ import annotations
+
+from aiida import orm
+
+AWB_UNAVAILABLE_MESSAGE = (
+    "The AiiDAlab widgets are not available. Please install it with "
+    "`pip install aiidalab-widgets-base` to use this feature."
+)
+
+
+def _load_awb_viewer():
+    from aiidalab_widgets_base import viewer  # noqa: PLC0415
+
+    return viewer
+
+
+def render_unavailable_preview() -> str:
+    """Return the fallback message shown when AWB is unavailable."""
+    return AWB_UNAVAILABLE_MESSAGE
+
+
+def render_node_preview(node: orm.Node) -> object:
+    """Render a node preview using AWB when it is available."""
+    try:
+        viewer = _load_awb_viewer()
+    except ImportError:
+        return render_unavailable_preview()
+
+    return viewer(node)

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -6,8 +6,8 @@ import ipywidgets as ipw
 from aiida import orm
 
 AWB_UNAVAILABLE_MESSAGE = (
-    "The AiiDAlab widgets are not available. Please install it with "
-    "<code>pip install aiidalab-widgets-base</code> to use this feature."
+    "For a richer output view, please install the AiiDAlab widgets with "
+    "<code>pip install aiidalab-widgets-base</code>."
 )
 
 

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipywidgets as ipw
 from aiida import orm
 
 AWB_UNAVAILABLE_MESSAGE = (
@@ -15,6 +16,7 @@ def render_node_preview(node: orm.Node) -> object:
     try:
         from aiidalab_widgets_base import viewer  # noqa: PLC0415
     except ImportError:
-        return AWB_UNAVAILABLE_MESSAGE
-
+        return ipw.HTML(
+            value=str(node) + "<br><em>" + AWB_UNAVAILABLE_MESSAGE + "</em>"
+        )
     return viewer(node)

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -7,7 +7,7 @@ from aiida import orm
 
 AWB_UNAVAILABLE_MESSAGE = (
     "The AiiDAlab widgets are not available. Please install it with "
-    "`pip install aiidalab-widgets-base` to use this feature."
+    "<code>pip install aiidalab-widgets-base</code> to use this feature."
 )
 
 

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -11,7 +11,7 @@ AWB_UNAVAILABLE_MESSAGE = (
 )
 
 
-def render_node_preview(node: orm.Node) -> object:
+def render_node_preview(node):
     """Render a node preview using AWB when it is available."""
     try:
         from aiidalab_widgets_base import viewer  # noqa: PLC0415

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -10,22 +10,11 @@ AWB_UNAVAILABLE_MESSAGE = (
 )
 
 
-def _load_awb_viewer():
-    from aiidalab_widgets_base import viewer  # noqa: PLC0415
-
-    return viewer
-
-
-def render_unavailable_preview() -> str:
-    """Return the fallback message shown when AWB is unavailable."""
-    return AWB_UNAVAILABLE_MESSAGE
-
-
 def render_node_preview(node: orm.Node) -> object:
     """Render a node preview using AWB when it is available."""
     try:
-        from aiidalab_widgets_base import viewer
+        from aiidalab_widgets_base import viewer  # noqa: PLC0415
     except ImportError:
-        return node
-    else:
-        return viewer(node)
+        return AWB_UNAVAILABLE_MESSAGE
+
+    return viewer(node)

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ipywidgets as ipw
-from aiida import orm
 
 AWB_UNAVAILABLE_MESSAGE = (
     "For a richer output view, please install the AiiDAlab widgets with "

--- a/home/node_preview.py
+++ b/home/node_preview.py
@@ -24,8 +24,8 @@ def render_unavailable_preview() -> str:
 def render_node_preview(node: orm.Node) -> object:
     """Render a node preview using AWB when it is available."""
     try:
-        viewer = _load_awb_viewer()
+        from aiidalab_widgets_base import viewer
     except ImportError:
-        return render_unavailable_preview()
-
-    return viewer(node)
+        return node
+    else:
+        return viewer(node)

--- a/home/process.py
+++ b/home/process.py
@@ -28,6 +28,8 @@ from aiida.common.links import LinkType
 from aiida.tools.query.calculation import CalculationQueryBuilder
 from IPython.display import HTML, Javascript, clear_output, display
 
+from home.node_preview import render_node_preview
+
 
 class CantRegisterCallbackError(Exception):
     """Exception raised when trying to register a callback after monitoring has started."""
@@ -304,22 +306,13 @@ class ProcessInputsWidget(ipw.VBox):
 
     def show_selected_input(self, change=None):
         """Function that displays process inputs selected in the `inputs` Dropdown widget."""
-        try:
-            from aiidalab_widgets_base import viewer  # noqa PLC0415
-
-            with self.output:
-                self.info.value = ""
-                clear_output()
-                if change["new"]:
-                    selected_input = orm.load_node(change["new"])
-                    self.info.value = f"PK: {selected_input.pk}"
-                    display(viewer(selected_input))
-        except ImportError:
-            self.output.clear_output()
-            with self.output:
-                print(
-                    "The AiiDAlab widgets are not available. Please install it with `pip install aiidalab-widgets-base` to use this feature."
-                )
+        with self.output:
+            self.info.value = ""
+            clear_output()
+            if change["new"]:
+                selected_input = orm.load_node(change["new"])
+                self.info.value = f"PK: {selected_input.pk}"
+                display(render_node_preview(selected_input))
 
 
 class ProcessMonitor(tl.HasTraits):
@@ -435,22 +428,13 @@ class ProcessOutputsWidget(ipw.VBox):
 
     def show_selected_output(self, change=None):
         """Function that displays process output selected in the `outputs` Dropdown widget."""
-        try:
-            from aiidalab_widgets_base import viewer  # noqa PLC0415
-
-            with self.output:
-                self.info.value = ""
-                clear_output()
-                if change["new"]:
-                    selected_output = self.process.outputs[change["new"]]
-                    self.info.value = f"PK: {selected_output.pk}"
-                    display(viewer(selected_output))
-        except ImportError:
-            self.output.clear_output()
-            with self.output:
-                print(
-                    "The AiiDAlab widgets are not available. Please install it with `pip install aiidalab-widgets-base` to use this feature."
-                )
+        with self.output:
+            self.info.value = ""
+            clear_output()
+            if change["new"]:
+                selected_output = self.process.outputs[change["new"]]
+                self.info.value = f"PK: {selected_output.pk}"
+                display(render_node_preview(selected_output))
 
 
 class ProcessReportWidget(ipw.HTML):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,23 +1,46 @@
-import sys
-import types
+import inspect
 
 import pytest
 from aiida import orm
 
+from home import node_preview
 from home import process as home_process
 
 pytestmark = pytest.mark.usefixtures("aiida_profile_clean")
 
 
 @pytest.fixture
-def mock_viewer_module(monkeypatch):
-    """Provide a lightweight viewer module for optional AWB integration paths."""
-    module = types.ModuleType("aiidalab_widgets_base")
-    module.viewer = lambda _: "mock-viewer"
-    monkeypatch.setitem(sys.modules, "aiidalab_widgets_base", module)
+def capture_display(monkeypatch):
+    displayed = []
+    monkeypatch.setattr(home_process, "display", displayed.append)
+    return displayed
 
 
-def test_process_inputs_widget(generate_calc_job_node, mock_viewer_module):
+def test_render_node_preview_uses_awb_when_available(monkeypatch):
+    node = orm.Int(1)
+
+    monkeypatch.setattr(
+        node_preview, "_load_awb_viewer", lambda: lambda _: "mock-viewer"
+    )
+
+    assert node_preview.render_node_preview(node) == "mock-viewer"
+
+
+def test_render_node_preview_returns_message_when_awb_is_unavailable(monkeypatch):
+    def raise_import_error():
+        raise ImportError
+
+    monkeypatch.setattr(node_preview, "_load_awb_viewer", raise_import_error)
+
+    assert (
+        node_preview.render_node_preview(orm.Int(1))
+        == node_preview.render_unavailable_preview()
+    )
+
+
+def test_process_inputs_widget_uses_node_preview_adapter(
+    generate_calc_job_node, monkeypatch, capture_display
+):
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -26,6 +49,8 @@ def test_process_inputs_widget(generate_calc_job_node, mock_viewer_module):
             },
         }
     )
+
+    monkeypatch.setattr(home_process, "render_node_preview", lambda _: "mock-viewer")
 
     home_process.ProcessInputsWidget()
 
@@ -38,9 +63,18 @@ def test_process_inputs_widget(generate_calc_job_node, mock_viewer_module):
     widget._inputs.value = nested_uuid
     selected_input = orm.load_node(nested_uuid)
     assert widget.info.value == f"PK: {selected_input.pk}"
+    assert capture_display == ["mock-viewer"]
 
 
-def test_process_outputs_widget(multiply_add_completed_workchain, mock_viewer_module):
+def test_process_outputs_widget_shows_unavailable_message(
+    multiply_add_completed_workchain, monkeypatch, capture_display
+):
+    monkeypatch.setattr(
+        home_process,
+        "render_node_preview",
+        lambda _: node_preview.render_unavailable_preview(),
+    )
+
     home_process.ProcessOutputsWidget()
 
     widget = home_process.ProcessOutputsWidget(process=multiply_add_completed_workchain)
@@ -48,6 +82,11 @@ def test_process_outputs_widget(multiply_add_completed_workchain, mock_viewer_mo
 
     selected_output = multiply_add_completed_workchain.outputs["result"]
     assert widget.info.value == f"PK: {selected_output.pk}"
+    assert capture_display == [node_preview.render_unavailable_preview()]
+
+
+def test_process_module_does_not_import_awb_directly():
+    assert "aiidalab_widgets_base" not in inspect.getsource(home_process)
 
 
 def test_process_report_widget(multiply_add_completed_workchain):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,4 +1,6 @@
 import inspect
+import sys
+import types
 
 import pytest
 from aiida import orm
@@ -18,23 +20,20 @@ def capture_display(monkeypatch):
 
 def test_render_node_preview_uses_awb_when_available(monkeypatch):
     node = orm.Int(1)
+    module = types.ModuleType("aiidalab_widgets_base")
+    module.viewer = lambda _: "mock-viewer"
 
-    monkeypatch.setattr(
-        node_preview, "_load_awb_viewer", lambda: lambda _: "mock-viewer"
-    )
+    monkeypatch.setitem(sys.modules, "aiidalab_widgets_base", module)
 
     assert node_preview.render_node_preview(node) == "mock-viewer"
 
 
 def test_render_node_preview_returns_message_when_awb_is_unavailable(monkeypatch):
-    def raise_import_error():
-        raise ImportError
-
-    monkeypatch.setattr(node_preview, "_load_awb_viewer", raise_import_error)
+    monkeypatch.delitem(sys.modules, "aiidalab_widgets_base", raising=False)
 
     assert (
         node_preview.render_node_preview(orm.Int(1))
-        == node_preview.render_unavailable_preview()
+        == node_preview.AWB_UNAVAILABLE_MESSAGE
     )
 
 
@@ -72,7 +71,7 @@ def test_process_outputs_widget_shows_unavailable_message(
     monkeypatch.setattr(
         home_process,
         "render_node_preview",
-        lambda _: node_preview.render_unavailable_preview(),
+        lambda _: node_preview.AWB_UNAVAILABLE_MESSAGE,
     )
 
     home_process.ProcessOutputsWidget()
@@ -82,7 +81,7 @@ def test_process_outputs_widget_shows_unavailable_message(
 
     selected_output = multiply_add_completed_workchain.outputs["result"]
     assert widget.info.value == f"PK: {selected_output.pk}"
-    assert capture_display == [node_preview.render_unavailable_preview()]
+    assert capture_display == [node_preview.AWB_UNAVAILABLE_MESSAGE]
 
 
 def test_process_module_does_not_import_awb_directly():

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,6 +1,7 @@
 import sys
 import types
 
+import ipywidgets as ipw
 import pytest
 from aiida import orm
 
@@ -30,10 +31,9 @@ def test_render_node_preview_uses_awb_when_available(monkeypatch):
 def test_render_node_preview_returns_message_when_awb_is_unavailable(monkeypatch):
     monkeypatch.delitem(sys.modules, "aiidalab_widgets_base", raising=False)
 
-    assert (
-        node_preview.render_node_preview(orm.Int(1))
-        == node_preview.AWB_UNAVAILABLE_MESSAGE
-    )
+    result = node_preview.render_node_preview(orm.Int(1))
+    assert isinstance(result, ipw.HTML)
+    assert node_preview.AWB_UNAVAILABLE_MESSAGE in result.value
 
 
 def test_process_inputs_widget_uses_node_preview_adapter(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,4 +1,3 @@
-import inspect
 import sys
 import types
 
@@ -82,10 +81,6 @@ def test_process_outputs_widget_shows_unavailable_message(
     selected_output = multiply_add_completed_workchain.outputs["result"]
     assert widget.info.value == f"PK: {selected_output.pk}"
     assert capture_display == [node_preview.AWB_UNAVAILABLE_MESSAGE]
-
-
-def test_process_module_does_not_import_awb_directly():
-    assert "aiidalab_widgets_base" not in inspect.getsource(home_process)
 
 
 def test_process_report_widget(multiply_add_completed_workchain):


### PR DESCRIPTION
AWB is still called in some places, but only to display widgets. In this PR we make sure that AWB is only called when it is installed. Otherwise, nothing is shown and a helper message is given to the user.